### PR TITLE
feat : Add default_error_pages map

### DIFF
--- a/server.hpp
+++ b/server.hpp
@@ -16,7 +16,8 @@ public:
     std::vector<Location>       loc; //로케이션 구조체 배열
     bool                        autoindex; //오토인덱스. (기본값 있음 - off)
     size_t                      client_max_body_size; //서버가 수신가능한 최대 데이터 크기. (기본값 있음 ????????)
-    std::string                 default_error_page; //기본 에러페이지. (기본값 있음)
+    std::map<int, std::string>  default_error_pages; // 키:status code 값:에러페이지
+    //std::string                 default_error_page; //기본 에러페이지. (기본값 있음)
     int                         fd; //linsten용 서버 fd.
     std::map<std::string,std::string>   cgi_map; // 키:확장자, 값:확장자 경로(python,java)
 

--- a/webserv.hpp
+++ b/webserv.hpp
@@ -6,7 +6,7 @@
 #include <stack>
 #include <unistd.h>
 #include <algorithm>
-#include "Server.hpp"
+#include "server.hpp"
 // #include "Client.hpp"
 #include <sys/socket.h> //socket
 // #include <sys/un.h>
@@ -150,8 +150,12 @@ public:
             }
             else if (split_result[0] == "error_page")
             {
+                int status_code;
                 util::remove_last_semicolon(split_result[1]);
-                _server_list.back()->default_error_page = split_result[1];
+                ss.str(split_result[1]);
+                ss >> status_code;
+                util::remove_last_semicolon(split_result[2]);
+                _server_list.back()->default_error_pages.insert(std::make_pair(status_code, split_result[2]));
             }
             else if (split_result[0] == "cgi")
             {


### PR DESCRIPTION
`error_page <status_code> <error.html>;` 형식을 처리할 수 있게 변경

`Server`의 `default_error_pages` 맵
- key: status_code
- value: status_code 에 해당하는 기본 에러 페이지